### PR TITLE
Fix possible buffer overflow in getFieldAddress

### DIFF
--- a/streamDevice/src/StreamEpics.cc
+++ b/streamDevice/src/StreamEpics.cc
@@ -62,6 +62,7 @@ extern DBBASE *pdbbase;
 #include <dbAccess.h>
 #include <registryFunction.h>
 #include <iocsh.h>
+#include <epicsStdio.h>
 
 #if EPICS_MODIFICATION<9
 extern "C" {
@@ -946,11 +947,11 @@ getFieldAddress(const char* fieldname, StreamBuffer& address)
         // FIELD in this record or VAL in other record
         char fullname[PVNAME_SZ + 6];
         const size_t fullnameLen = sizeof(fullname);
-        snprintf(fullname, fullnameLen, "%s.%s", name(), fieldname);
+        epicsSnprintf(fullname, fullnameLen, "%s.%s", name(), fieldname);
         if (dbNameToAddr(fullname, &dbaddr) != OK)
         {
             // VAL in other record
-            snprintf(fullname, fullnameLen, "%s.VAL", fieldname);
+            epicsSnprintf(fullname, fullnameLen, "%s.VAL", fieldname);
             if (dbNameToAddr(fullname, &dbaddr) != OK) return false;
         }
     }

--- a/streamDevice/src/StreamEpics.cc
+++ b/streamDevice/src/StreamEpics.cc
@@ -944,7 +944,7 @@ getFieldAddress(const char* fieldname, StreamBuffer& address)
     else
     {
         // FIELD in this record or VAL in other record
-        char fullname[PVNAME_SZ + 1];
+        char fullname[PVNAME_SZ + 6];
         const size_t fullnameLen = sizeof(fullname);
         snprintf(fullname, fullnameLen, "%s.%s", name(), fieldname);
         if (dbNameToAddr(fullname, &dbaddr) != OK)

--- a/streamDevice/src/StreamEpics.cc
+++ b/streamDevice/src/StreamEpics.cc
@@ -944,8 +944,8 @@ getFieldAddress(const char* fieldname, StreamBuffer& address)
     else
     {
         // FIELD in this record or VAL in other record
-        size_t fullnameLen = PVNAME_SZ + 1;
-        char fullname[fullnameLen];
+        char fullname[PVNAME_SZ + 1];
+        const size_t fullnameLen = sizeof(fullname);
         snprintf(fullname, fullnameLen, "%s.%s", name(), fieldname);
         if (dbNameToAddr(fullname, &dbaddr) != OK)
         {

--- a/streamDevice/src/StreamEpics.cc
+++ b/streamDevice/src/StreamEpics.cc
@@ -944,12 +944,13 @@ getFieldAddress(const char* fieldname, StreamBuffer& address)
     else
     {
         // FIELD in this record or VAL in other record
-        char fullname[PVNAME_SZ + 1];
-        sprintf(fullname, "%s.%s", name(), fieldname);
+        size_t fullnameLen = PVNAME_SZ + 1;
+        char fullname[fullnameLen];
+        snprintf(fullname, fullnameLen, "%s.%s", name(), fieldname);
         if (dbNameToAddr(fullname, &dbaddr) != OK)
         {
             // VAL in other record
-            sprintf(fullname, "%s.VAL", fieldname);
+            snprintf(fullname, fullnameLen, "%s.VAL", fieldname);
             if (dbNameToAddr(fullname, &dbaddr) != OK) return false;
         }
     }


### PR DESCRIPTION
When `StreamProtocolParser::Protocol::compileFormat` finds a
`%(other_pv)d` format specifier it calls `Stream::getFieldAddress`.

`getFieldAddress` will first try to interpret `other_pv` as a field name
checking for the existence of `this_pv.other_pv`. If it doesn't find
such PV it will then assume the format points to `other_pv.VAL`.

If both `this_pv` and `other_pv` have long names they will cause an
overflow on the buffer `fullname`, which has a size of `PVNAME_SZ+1 = 61`.

This fix replaces `sprintf` calls with `snprintf` within `Stream::getFieldAddress`.

Fixes #1 
